### PR TITLE
CHANGE: add pwd to the symlink path to fix lib determine.

### DIFF
--- a/build_mesos
+++ b/build_mesos
@@ -261,7 +261,8 @@ function create_installation {(
 )}
 
 function create_lib_symlinks {(
-  if [[ -f usr/lib64/libmesos.so ]]; then
+  local pwd="$(pwd -P)"
+  if [[ -f $pwd/toor/usr/lib64/libmesos.so ]]; then
     libdir=lib64
   else
     libdir=lib


### PR DESCRIPTION
@ridv Like we talked, here comes the PR with the changes of how we find out that if there is a lib64 directory. 

The problem was, that it could not find `libmesos.so` because of the missing "toor" subfolder in the path. 
```
Create symlinks for backwards compatibility (e.g. Marathon currently
expects libmesos.so to exist in /usr/local/lib).
cp: cannot stat '../../lib/lib*.so': No such file or directory
```