### PR TITLE
DEL: remove zookeeper dependencies of deb package.

### DIFF
--- a/build_mesos
+++ b/build_mesos
@@ -352,9 +352,6 @@ function deb_ {
   esac
 
   local opts=( -t deb
-               --deb-recommends zookeeper
-               --deb-recommends zookeeperd
-               --deb-recommends zookeeper-bin
                -d 'java-runtime-headless | java2-runtime-headless | default-jre'
                -d $libcurl_package
                -d libevent-dev


### PR DESCRIPTION
I'm sorry for so many PR. :-(

Well, with these PR I want to remove the not necessary dependencies to zookeeper. The mesos binaries does not need it. But with the dependencies, we also install zookeeper on mesos agents. I think that makes no sense. Am I wrong? 